### PR TITLE
[improve]A checkpoint only requires the creation of one transaction

### DIFF
--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittable.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittable.java
@@ -31,20 +31,30 @@ public class PulsarCommittable {
     /** The transaction id. */
     private final TxnID txnID;
 
-    /** The topic name with partition information. */
-    private final String topic;
-
+    /**
+     * To ensure compatibility after degradation, the new version can still restore the PulsarCommittable
+     * object already stored in the old version and keep this constructor.
+     * @deprecated the param @param topic is meaningless now.
+     */
+    @Deprecated
     public PulsarCommittable(TxnID txnID, String topic) {
+        this(txnID);
+    }
+
+    public PulsarCommittable(TxnID txnID) {
         this.txnID = txnID;
-        this.topic = topic;
     }
 
     public TxnID getTxnID() {
         return txnID;
     }
 
+    /**
+     * @deprecated the param @param topic is meaningless now.
+     */
+    @Deprecated
     public String getTopic() {
-        return topic;
+        return PulsarCommittableSerializer.TOPIC_PLACEHOLDER;
     }
 
     @Override
@@ -56,16 +66,16 @@ public class PulsarCommittable {
             return false;
         }
         PulsarCommittable that = (PulsarCommittable) o;
-        return Objects.equals(txnID, that.txnID) && Objects.equals(topic, that.topic);
+        return Objects.equals(txnID, that.txnID);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(txnID, topic);
+        return Objects.hash(txnID);
     }
 
     @Override
     public String toString() {
-        return "PulsarCommittable{" + "txnID=" + txnID + ", topic='" + topic + '\'' + '}';
+        return "PulsarCommittable{" + "txnID=" + txnID + '}';
     }
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittable.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittable.java
@@ -32,8 +32,9 @@ public class PulsarCommittable {
     private final TxnID txnID;
 
     /**
-     * To ensure compatibility after degradation, the new version can still restore the PulsarCommittable
-     * object already stored in the old version and keep this constructor.
+     * To ensure compatibility after degradation, the new version can still restore the
+     * PulsarCommittable object already stored in the old version and keep this constructor.
+     *
      * @deprecated the param @param topic is meaningless now.
      */
     @Deprecated
@@ -49,9 +50,7 @@ public class PulsarCommittable {
         return txnID;
     }
 
-    /**
-     * @deprecated the param @param topic is meaningless now.
-     */
+    /** @deprecated the param @param topic is meaningless now. */
     @Deprecated
     public String getTopic() {
         return PulsarCommittableSerializer.TOPIC_PLACEHOLDER;

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittableSerializer.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittableSerializer.java
@@ -46,7 +46,8 @@ public class PulsarCommittableSerializer implements SimpleVersionedSerializer<Pu
             TxnID txnID = obj.getTxnID();
             out.writeLong(txnID.getMostSigBits());
             out.writeLong(txnID.getLeastSigBits());
-            // To ensure compatibility after degradation, the old version can still restore the PulsarCommittable
+            // To ensure compatibility after degradation, the old version can still restore the
+            // PulsarCommittable
             // object already stored in the new version and write a meaningless topic name.
             out.writeUTF(TOPIC_PLACEHOLDER);
             out.flush();

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittableSerializer.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommittableSerializer.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 public class PulsarCommittableSerializer implements SimpleVersionedSerializer<PulsarCommittable> {
 
     private static final int CURRENT_VERSION = 1;
+    public static final String TOPIC_PLACEHOLDER = "Topic_Placeholder";
 
     @Override
     public int getVersion() {
@@ -45,7 +46,9 @@ public class PulsarCommittableSerializer implements SimpleVersionedSerializer<Pu
             TxnID txnID = obj.getTxnID();
             out.writeLong(txnID.getMostSigBits());
             out.writeLong(txnID.getLeastSigBits());
-            out.writeUTF(obj.getTopic());
+            // To ensure compatibility after degradation, the old version can still restore the PulsarCommittable
+            // object already stored in the new version and write a meaningless topic name.
+            out.writeUTF(TOPIC_PLACEHOLDER);
             out.flush();
             return baos.toByteArray();
         }
@@ -58,8 +61,7 @@ public class PulsarCommittableSerializer implements SimpleVersionedSerializer<Pu
             long mostSigBits = in.readLong();
             long leastSigBits = in.readLong();
             TxnID txnID = new TxnID(mostSigBits, leastSigBits);
-            String topic = in.readUTF();
-            return new PulsarCommittable(txnID, topic);
+            return new PulsarCommittable(txnID);
         }
     }
 }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommitter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/committer/PulsarCommitter.java
@@ -75,9 +75,8 @@ public class PulsarCommitter implements Committer<PulsarCommittable>, Closeable 
         for (CommitRequest<PulsarCommittable> request : requests) {
             PulsarCommittable committable = request.getCommittable();
             TxnID txnID = committable.getTxnID();
-            String topic = committable.getTopic();
 
-            LOG.debug("Start committing the Pulsar transaction {} for topic {}", txnID, topic);
+            LOG.info("Start committing the Pulsar transaction {}", txnID);
             try {
                 client.commit(txnID);
             } catch (CoordinatorNotFoundException e) {
@@ -122,9 +121,8 @@ public class PulsarCommitter implements Committer<PulsarCommittable>, Closeable 
                 request.signalFailedWithKnownReason(e);
             } catch (TransactionCoordinatorClientException e) {
                 LOG.error(
-                        "Encountered retriable exception while committing transaction {} for topic {}.",
+                        "Encountered retriable exception while committing transaction {}.",
                         committable,
-                        topic,
                         e);
                 int maxRecommitTimes = sinkConfiguration.getMaxRecommitTimes();
                 if (request.getNumberOfRetries() < maxRecommitTimes) {

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -54,7 +54,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Collections.emptyList;
@@ -139,8 +138,6 @@ public class PulsarWriter<IN> implements CommittingSinkWriter<IN, PulsarCommitta
         this.pendingMessages = new AtomicLong(0);
     }
 
-    AtomicInteger msgCount = new AtomicInteger(0);
-
     @Override
     public void write(IN element, Context context) throws IOException, InterruptedException {
         PulsarMessage<?> message = serializationSchema.serialize(element, sinkContext);
@@ -150,8 +147,6 @@ public class PulsarWriter<IN> implements CommittingSinkWriter<IN, PulsarCommitta
         List<TopicPartition> partitions = metadataListener.availablePartitions();
         TopicPartition partition = topicRouter.route(element, key, partitions, sinkContext);
         String topic = partition.getFullTopicName();
-
-        LOG.info("===> publishing " + msgCount.incrementAndGet());
 
         // Create message builder for sending messages.
         TypedMessageBuilder<?> builder = createMessageBuilder(topic, context, message);

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.connector.pulsar.sink.writer;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
@@ -55,6 +54,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Collections.emptyList;

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.pulsar.sink.writer;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
@@ -138,6 +139,8 @@ public class PulsarWriter<IN> implements CommittingSinkWriter<IN, PulsarCommitta
         this.pendingMessages = new AtomicLong(0);
     }
 
+    AtomicInteger msgCount = new AtomicInteger(0);
+
     @Override
     public void write(IN element, Context context) throws IOException, InterruptedException {
         PulsarMessage<?> message = serializationSchema.serialize(element, sinkContext);
@@ -147,6 +150,8 @@ public class PulsarWriter<IN> implements CommittingSinkWriter<IN, PulsarCommitta
         List<TopicPartition> partitions = metadataListener.availablePartitions();
         TopicPartition partition = topicRouter.route(element, key, partitions, sinkContext);
         String topic = partition.getFullTopicName();
+
+        LOG.info("===> publishing " + msgCount.incrementAndGet());
 
         // Create message builder for sending messages.
         TypedMessageBuilder<?> builder = createMessageBuilder(topic, context, message);

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
@@ -275,6 +275,7 @@ public class ProducerRegister implements Closeable {
 
     /**
      * Get the cached transaction. Or create a new transaction after checkpointing.
+     *
      * @param topic Just for logging.
      */
     private Transaction getOrCreateTransaction(String topic) throws PulsarClientException {

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
@@ -274,7 +274,8 @@ public class ProducerRegister implements Closeable {
     }
 
     /**
-     * Get the cached topic-related transaction. Or create a new transaction after checkpointing.
+     * Get the cached transaction. Or create a new transaction after checkpointing.
+     * @param topic Just for logging.
      */
     private Transaction getOrCreateTransaction(String topic) throws PulsarClientException {
         if (transaction != null) {

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.pulsar.sink.writer.topic;
 
+import java.util.Collections;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.pulsar.common.crypto.PulsarCrypto;
@@ -25,6 +26,7 @@ import org.apache.flink.connector.pulsar.common.metrics.ProducerMetricsIntercept
 import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils;
 import org.apache.flink.connector.pulsar.sink.committer.PulsarCommittable;
 import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
+import org.apache.flink.connector.pulsar.sink.writer.PulsarWriter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -63,6 +65,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createClient;
 import static org.apache.flink.connector.pulsar.common.metrics.MetricNames.NUM_ACKS_RECEIVED;
@@ -94,6 +98,8 @@ import static org.apache.flink.connector.pulsar.sink.config.PulsarSinkConfigUtil
 @Internal
 public class ProducerRegister implements Closeable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ProducerRegister.class);
+
     private static final String FAIL_TO_CREATE_TOPIC =
             "Fail to create the non-exist topic, make sure you have enable the topic auto creation in Pulsar.";
 
@@ -104,7 +110,7 @@ public class ProducerRegister implements Closeable {
     private final SinkWriterMetricGroup metricGroup;
     private final Map<String, Schema<byte[]>> schemas;
     private final Map<String, Map<SchemaHash, Producer<?>>> producers;
-    private final Map<String, Transaction> transactions;
+    private Transaction transaction;
 
     public ProducerRegister(
             SinkConfiguration sinkConfiguration,
@@ -117,7 +123,6 @@ public class ProducerRegister implements Closeable {
         this.metricGroup = metricGroup;
         this.schemas = new HashMap<>();
         this.producers = new HashMap<>();
-        this.transactions = new HashMap<>();
 
         if (sinkConfiguration.isEnableMetrics()) {
             metricGroup.setCurrentSendTimeGauge(this::currentSendTimeGauge);
@@ -162,17 +167,15 @@ public class ProducerRegister implements Closeable {
      * be removed until Flink triggered a checkpoint.
      */
     public List<PulsarCommittable> prepareCommit() {
-        List<PulsarCommittable> committables = new ArrayList<>(transactions.size());
-        for (Map.Entry<String, Transaction> entry : transactions.entrySet()) {
-            String topic = entry.getKey();
-            Transaction transaction = entry.getValue();
-            TxnID txnID = transaction.getTxnID();
-
-            committables.add(new PulsarCommittable(txnID, topic));
+        if (transaction !=null) {
+            LOG.info("===> prepare Commit transaction {}", String.valueOf(transaction.getTxnID()));
+        } else {
+            LOG.info("===> prepare Commit transaction null");
+            return Collections.emptyList();
         }
-        transactions.clear();
-
-        return committables;
+        TxnID txnID = transaction.getTxnID();
+        transaction = null;
+        return Collections.singletonList(new PulsarCommittable(txnID, ""));
     }
 
     /**
@@ -276,14 +279,14 @@ public class ProducerRegister implements Closeable {
      * Get the cached topic-related transaction. Or create a new transaction after checkpointing.
      */
     private Transaction getOrCreateTransaction(String topic) throws PulsarClientException {
-        if (transactions.containsKey(topic)) {
-            return transactions.get(topic);
+        if (transaction != null) {
+            LOG.info("===> got cached transaction " + topic);
+            return transaction;
         }
 
         long timeoutMillis = sinkConfiguration.getTransactionTimeoutMillis();
-        Transaction transaction = createTransaction(pulsarClient, timeoutMillis);
-        transactions.put(topic, transaction);
-
+        transaction = createTransaction(pulsarClient, timeoutMillis);
+        LOG.info("===> created transaction {} {}", transaction.getTxnID(), topic);
         return transaction;
     }
 
@@ -301,17 +304,14 @@ public class ProducerRegister implements Closeable {
 
     /** Abort the existed transactions. This method would be used when closing PulsarWriter. */
     private void abortTransactions() {
-        if (coordinatorClient == null || transactions.isEmpty()) {
+        if (coordinatorClient == null || transaction == null) {
             return;
         }
 
         try (Closer closer = Closer.create()) {
-            for (Transaction transaction : transactions.values()) {
-                TxnID txnID = transaction.getTxnID();
-                closer.register(() -> coordinatorClient.abort(txnID));
-            }
-
-            transactions.clear();
+            TxnID txnID = transaction.getTxnID();
+            closer.register(() -> coordinatorClient.abort(txnID));
+            transaction = null;
         } catch (IOException e) {
             throw new FlinkRuntimeException(e);
         }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
@@ -320,15 +320,15 @@ public class ProducerRegister implements Closeable {
             return;
         }
 
+        TxnID txnID = transaction.getTxnID();
         try (Closer closer = Closer.create()) {
-            TxnID txnID = transaction.getTxnID();
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Abort transaction. transaction: {}", txnID);
             }
             closer.register(() -> coordinatorClient.abort(txnID));
             transaction = null;
         } catch (IOException e) {
-            LOG.error("Failed to abort transaction {}.", transaction.getTxnID(), e);
+            LOG.error("Failed to abort transaction {}.", txnID, e);
             throw new FlinkRuntimeException(e);
         }
     }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
@@ -26,7 +26,6 @@ import org.apache.flink.connector.pulsar.common.metrics.ProducerMetricsIntercept
 import org.apache.flink.connector.pulsar.common.schema.PulsarSchemaUtils;
 import org.apache.flink.connector.pulsar.sink.committer.PulsarCommittable;
 import org.apache.flink.connector.pulsar.sink.config.SinkConfiguration;
-import org.apache.flink.connector.pulsar.sink.writer.PulsarWriter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -58,7 +57,6 @@ import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,15 +165,15 @@ public class ProducerRegister implements Closeable {
      * be removed until Flink triggered a checkpoint.
      */
     public List<PulsarCommittable> prepareCommit() {
-        if (transaction !=null) {
-            LOG.info("===> prepare Commit transaction {}", String.valueOf(transaction.getTxnID()));
+        if (transaction != null) {
+            LOG.info("Prepare Commit transaction {}", transaction.getTxnID());
         } else {
-            LOG.info("===> prepare Commit transaction null");
+            LOG.info("Prepare Commit transaction null");
             return Collections.emptyList();
         }
         TxnID txnID = transaction.getTxnID();
         transaction = null;
-        return Collections.singletonList(new PulsarCommittable(txnID, ""));
+        return Collections.singletonList(new PulsarCommittable(txnID));
     }
 
     /**
@@ -280,13 +278,17 @@ public class ProducerRegister implements Closeable {
      */
     private Transaction getOrCreateTransaction(String topic) throws PulsarClientException {
         if (transaction != null) {
-            LOG.info("===> got cached transaction " + topic);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Got cached transaction. transaction: {}, topic: {}", transaction.getTxnID(), topic);
+            }
             return transaction;
         }
 
         long timeoutMillis = sinkConfiguration.getTransactionTimeoutMillis();
         transaction = createTransaction(pulsarClient, timeoutMillis);
-        LOG.info("===> created transaction {} {}", transaction.getTxnID(), topic);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Created new transaction. transaction: {}, topic: {}", transaction.getTxnID(), topic);
+        }
         return transaction;
     }
 
@@ -305,14 +307,21 @@ public class ProducerRegister implements Closeable {
     /** Abort the existed transactions. This method would be used when closing PulsarWriter. */
     private void abortTransactions() {
         if (coordinatorClient == null || transaction == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Abort transaction. transaction: null");
+            }
             return;
         }
 
         try (Closer closer = Closer.create()) {
             TxnID txnID = transaction.getTxnID();
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Abort transaction. transaction: {}", txnID);
+            }
             closer.register(() -> coordinatorClient.abort(txnID));
             transaction = null;
         } catch (IOException e) {
+            LOG.error("Failed to abort transaction {}.", transaction.getTxnID(), e);
             throw new FlinkRuntimeException(e);
         }
     }

--- a/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
+++ b/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/ProducerRegister.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.connector.pulsar.sink.writer.topic;
 
-import java.util.Collections;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 import org.apache.flink.connector.pulsar.common.crypto.PulsarCrypto;
@@ -52,19 +51,20 @@ import org.apache.pulsar.common.protocol.schema.SchemaHash;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.apache.pulsar.shade.com.google.common.base.Strings;
 import org.apache.pulsar.shade.com.google.common.io.Closer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createClient;
 import static org.apache.flink.connector.pulsar.common.metrics.MetricNames.NUM_ACKS_RECEIVED;
@@ -279,7 +279,10 @@ public class ProducerRegister implements Closeable {
     private Transaction getOrCreateTransaction(String topic) throws PulsarClientException {
         if (transaction != null) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Got cached transaction. transaction: {}, topic: {}", transaction.getTxnID(), topic);
+                LOG.debug(
+                        "Got cached transaction. transaction: {}, topic: {}",
+                        transaction.getTxnID(),
+                        topic);
             }
             return transaction;
         }
@@ -287,7 +290,10 @@ public class ProducerRegister implements Closeable {
         long timeoutMillis = sinkConfiguration.getTransactionTimeoutMillis();
         transaction = createTransaction(pulsarClient, timeoutMillis);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Created new transaction. transaction: {}, topic: {}", transaction.getTxnID(), topic);
+            LOG.debug(
+                    "Created new transaction. transaction: {}, topic: {}",
+                    transaction.getTxnID(),
+                    topic);
         }
         return transaction;
     }


### PR DESCRIPTION
## Purpose of the change

In the initial design, a checkpoint would create multiple transactions, which would result in the possibility that some transactions were successfully committed while others failed. Once this situation occurs, a `timeout` exception will be thrown (when the Pulsar broker discovers that a transaction no longer exists and has actually been deleted due to being committed).

However, Pulsar supports transactions across topics and namespaces, so only one transaction is needed for one checkpoint

This will ensure strong consistency, enhance performance and avoid error reports

## Significant changes

*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for
convenience.)*

- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
    - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)
